### PR TITLE
Switch to "fresh" go reload tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ src/github.com
 src/golang.org
 src/gopkg.in
 src/code.google.com
+tmp/
 *.env
-gin-bin
 users.csv
+fresh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deps fmt build clean gin
+.PHONY: deps fmt build clean serve
 export GOPATH=$(shell pwd)
 
 deps:
@@ -13,5 +13,9 @@ build: deps
 clean:
 	go clean -i -r helios/...
 
-gin:
-	cd src/helios && gin -i -a 8888 -p 8989
+serve:
+ifeq ("$(wildcard $(./bin/fresh))","")
+	@go get github.com/pilu/fresh
+	@go install github.com/pilu/fresh
+endif
+	@./bin/fresh -c fresh.conf

--- a/README.md
+++ b/README.md
@@ -9,19 +9,8 @@ This is used for building the release but can also be used for development:
     ./bin/helios
 
 
-## Enable Auto Compile (optional)
-The strategy I use for rapid development with auto compiling:
+## Auto Compile (for rapid development)
 
-Add a default GOPATH and add that GOPATH to the PATH:
+Use the serve build command to auto compile when changes are made:
 
-    export GOPATH=/Users/<username>/go
-    export PATH=$GOPATH/bin/:$PATH
-
-Install the gin watch tool and verify it installed correctly:
-
-    go get github.com/codegangsta/gin
-    gin -h
-
-Use the gin build command to auto compile when changes are made:
-
-    make gin
+    make serve

--- a/fresh.conf
+++ b/fresh.conf
@@ -1,0 +1,6 @@
+root:              ./src/helios
+tmp_path:          ./tmp
+build_name:        fresh
+build_log:         fresh-errors.log
+valid_ext:         .go
+build_delay:       500


### PR DESCRIPTION
gin was having issues with the package structure. This also allowed for
a more strait forward install and usage.
